### PR TITLE
Complete URL for npm website

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ These are the design goals:
 In it’s simplest form, you just use it as a `parseFloat` replacement.
 
 ## Install
-#### Install with [npm](npmjs.org)
+#### Install with [npm](https://npmjs.org)
 
 ```bash
 npm i parse-decimal-number --save


### PR DESCRIPTION
Without the `https://` the was pointing to a 404 page on github